### PR TITLE
refactor(studio): collapse graph/atlas into uniform view: refs

### DIFF
--- a/.ai/knowledge/ryeos/development/release-process.md
+++ b/.ai/knowledge/ryeos/development/release-process.md
@@ -1,4 +1,4 @@
-<!-- ryeos:signed:2026-06-15T04:48:21Z:ff07780ad489397517a7b9e511e98c65da1fa1a5710841b92231b3c22d42d06b:SqyrHUlU+nDF6R1LM2UQqtDLtQ1n94brrX/YB6MgWTpPhX2VL3I5K8guyOwEW+KDe1NgGGVVD2MSX3KZgoA+Bg==:64f806fe8f81efdecf5245e1b1941aeecfe3a56ff1826adc1214538ab69953ca -->
+<!-- ryeos:signed:2026-06-15T05:35:51Z:ba71436da4b872fc0f02101a6a5f5a22f526a5884ff75828a6a2e6455c8f6d22:WaCfa2Bu+rjoW3K/ViVtIWct61tkcWSgiuBPk0ZUoyZ5FV8p7dXyzxACaIoCmMwTb8g34rCz5vcWokrqkRJ4AA==:64f806fe8f81efdecf5245e1b1941aeecfe3a56ff1826adc1214538ab69953ca -->
 ```yaml
 category: "ryeos/development"
 name: "release-process"
@@ -72,13 +72,20 @@ tag, push, then switch back to `next`:
 ```bash
 cd /home/leo/projects/ryeos-next
 git fetch origin
-git checkout -b main origin/main           # only valid because main is checked out nowhere
+git branch -f main origin/main             # create OR reset local main to the remote tip
+git checkout main                          # (don't use `checkout -b main` — it errors if a
+                                           #  stale local main from a prior release exists)
 git merge --no-ff next -m "Merge next into main for v$new release"
 # ... validate, tag, push (sections 5–7) ...
 git checkout next                          # leave this worktree on next
+git branch -D main                         # delete the local main so the next release starts clean
 ```
 
-This was the path used for the v0.5.16 release.
+Tag and push from the resulting `main` HEAD (the merge commit). Watch out: if
+`checkout -b main` silently fails because a local `main` already exists, the
+merge runs as a no-op on `next` and the tag lands on a `next` commit while
+`origin/main` stays stale. `git branch -f` + deleting `main` afterward avoids
+this. This was the path used for the v0.5.16 / v0.5.17 releases.
 
 ## 1. Decide whether to move a tag or cut a new patch
 

--- a/bundles/studio/.ai/surfaces/ryeos/studio/workbench.yaml
+++ b/bundles/studio/.ai/surfaces/ryeos/studio/workbench.yaml
@@ -1,4 +1,4 @@
-# ryeos:signed:2026-06-13T05:38:46Z:64714c11fe756ced083a2a44b2f89be58aa868bfb756827c01512b01a055b13c:MnWFwrYeyywvVmq0Tzc+ZWIpX3K0bYn6CzPlKMJUId+jJ4SOSY/vjcKLIQpqIhT4cVNE9s/zgT6Z9vVQOG3YDA==:741a8bc609b398aaec0685e5aefb682faf5129a66bd192f888d23bb642c18eea
+# ryeos:signed:2026-06-17T01:35:08Z:14c93d73342d11d42144edf173211e4c1d47c6200e0962679a737ecf53121e41:Yfo5h2/G9SFeKlWJxm6/jan0huaTFPEX/UraP6OvNNj+nqQamsvu3SHhuS6rqTp2elzTlmMmohU58fkADwSCAA==:741a8bc609b398aaec0685e5aefb682faf5129a66bd192f888d23bb642c18eea
 name: studio-workbench
 version: "1.0.0"
 description: Working seat - home pane beside a content-bound thread list
@@ -10,7 +10,7 @@ tiling:
   insert: end
 
 tiles:
-  - graph
+  - "view:ryeos/graph/topology"
   - "view:ryeos/threads/list"
 
 slots:
@@ -21,6 +21,8 @@ style:
   border: thin
 
 library:
+  - view:ryeos/graph/topology
+  - view:ryeos/atlas
   - view:ryeos/threads/list
   - view:ryeos/item/inspector
   - view:ryeos/chain/timeline

--- a/bundles/studio/.ai/views/ryeos/atlas.yaml
+++ b/bundles/studio/.ai/views/ryeos/atlas.yaml
@@ -1,0 +1,12 @@
+# ryeos:signed:2026-06-17T01:35:08Z:b1227cf88360a384d967418f801fff205401f57bb570ebdc6e28704ea830354f:0KnUhKebMX63lG63VPN/BqXlJ2eXbBeLyn2R6yX2/0CTpxqEffAfyPDGngb3VXZeuB3peOm2NOxbnUznxS9KBA==:741a8bc609b398aaec0685e5aefb682faf5129a66bd192f888d23bb642c18eea
+name: atlas
+version: "1.0.0"
+description: >-
+  The 2D namespace atlas — items laid out by namespace and kind across the
+  AI-space and file-space projections — built by the engine from live item
+  data. Each atlas tile keeps its own arrangement: which layers are
+  visible, the active lens, and the projection are per-tile, so one surface
+  can host several independent atlas views. The atlas is content (an
+  `atlas` widget), drawn by the one generic scene renderer.
+
+widget: atlas

--- a/bundles/studio/.ai/views/ryeos/graph/topology.yaml
+++ b/bundles/studio/.ai/views/ryeos/graph/topology.yaml
@@ -1,0 +1,11 @@
+# ryeos:signed:2026-06-17T01:35:08Z:31bf3332b5490431fea83144e9bfe567322875a89b8c5fe5ab08237f5b5e51fe:N4+mZV87HjXlqGyAO46A0+NYtlHUHJGzAE+46ywIzTp+bX3+8FVvLAQMYX/alMFwScRf8ri2XIiSEfATwVnVDg==:741a8bc609b398aaec0685e5aefb682faf5129a66bd192f888d23bb642c18eea
+name: graph-topology
+version: "1.0.0"
+description: >-
+  The RyeOS topology as a 3D scene — local node, projects, services, and
+  their links — built by the engine from live topology data. Selecting it
+  as a center tile renders the map. The graph is content (a `graph`
+  widget), drawn by the one generic scene renderer; it is not a renderer
+  case. New topology views are new view items, never engine code.
+
+widget: graph

--- a/crates/clients/base/src/studio/event.rs
+++ b/crates/clients/base/src/studio/event.rs
@@ -117,18 +117,27 @@ pub enum StudioUiEvent {
         path: String,
     },
     SetAtlasLayerVisible {
+        /// Target tile; `None` (default) targets the ambient backdrop atlas.
+        #[serde(default)]
+        tile_id: Option<String>,
         kind: AtlasItemKind,
         visible: bool,
     },
     SetAtlasLens {
+        #[serde(default)]
+        tile_id: Option<String>,
         lens: AtlasLensVm,
     },
     SetAtlasProjection {
+        #[serde(default)]
+        tile_id: Option<String>,
         projection: AtlasProjectionVm,
         #[serde(default)]
         root: Option<String>,
     },
     SetAtlasFileSpacePath {
+        #[serde(default)]
+        tile_id: Option<String>,
         root: String,
         path: String,
     },

--- a/crates/clients/base/src/studio/model.rs
+++ b/crates/clients/base/src/studio/model.rs
@@ -298,8 +298,17 @@ pub struct StudioUiState {
     pub input_buffers: BTreeMap<String, StudioInputState>,
     #[serde(default)]
     pub docks: StudioDockState,
+    /// Ambient/backdrop atlas state — the empty-center `namespace_atlas`
+    /// background. Surface-level, not a tile. Per-tile Atlas tiles keep
+    /// their own arrangement in [`Self::tile_atlas`].
     #[serde(default)]
     pub atlas: AtlasUiStateVm,
+    /// Per-tile atlas arrangements, keyed by tile id (string). Atlas/graph
+    /// were never meant to show one fixed thing — a surface can host
+    /// several independent atlas tiles, each with its own layers, lens,
+    /// and projection. A tile with no entry falls back to [`Self::atlas`].
+    #[serde(default)]
+    pub tile_atlas: BTreeMap<String, AtlasUiStateVm>,
     pub motion: Vec<StudioMotionEventVm>,
     pub loading: BTreeMap<String, bool>,
     pub notices: Vec<StudioNotice>,
@@ -319,6 +328,7 @@ impl Default for StudioUiState {
             input_buffers: BTreeMap::new(),
             docks: StudioDockState::default(),
             atlas: AtlasUiStateVm::default(),
+            tile_atlas: BTreeMap::new(),
             motion: Vec::new(),
             loading: BTreeMap::new(),
             notices: Vec::new(),
@@ -477,18 +487,21 @@ impl StudioCore {
             let Some(tile) = self.workspace.tiles.get(&tile_id) else {
                 continue;
             };
-            match &tile.view {
-                ViewSpec::Bound { view_ref } => {
-                    bound_tiles.push((tile_id, view_ref.clone()));
-                }
-                ViewSpec::Atlas => {
-                    match self.ui.atlas.active_projection {
+            let view_ref = tile.view.view_ref.clone();
+            bound_tiles.push((tile_id, view_ref.clone()));
+            // The scene widgets need engine data the generic source path
+            // doesn't carry: graph wants topology, atlas wants topology plus
+            // items or file space (per this tile's projection).
+            match self.views.get(&view_ref).map(|binding| binding.widget.as_str()) {
+                Some("atlas") => {
+                    match self.tile_atlas_state(tile_id).active_projection {
                         crate::atlas::AtlasProjectionVm::AiSpace => needs_atlas_items = true,
                         crate::atlas::AtlasProjectionVm::FileSpace => needs_file_space = true,
                     }
                     needs_topology = true;
                 }
-                ViewSpec::Graph { .. } => needs_topology = true,
+                Some("graph") => needs_topology = true,
+                _ => {}
             }
         }
 
@@ -538,9 +551,7 @@ impl StudioCore {
             .into_iter()
             .filter_map(|tile_id| {
                 let tile = self.workspace.tiles.get(&tile_id)?;
-                let ViewSpec::Bound { view_ref } = &tile.view else {
-                    return None;
-                };
+                let view_ref = &tile.view.view_ref;
                 let binding = self.views.get(view_ref)?;
                 (binding.refresh.get("on_hint").and_then(|v| v.as_str()) == Some(kind))
                     .then(|| (tile_id, view_ref.clone()))
@@ -643,6 +654,15 @@ impl StudioCore {
         self.generation = self.generation.saturating_add(1);
     }
 
+    /// Atlas arrangement for a specific tile, falling back to the ambient
+    /// backdrop state when the tile has no per-tile entry yet.
+    pub(crate) fn tile_atlas_state(&self, tile_id: crate::ids::TileId) -> &AtlasUiStateVm {
+        self.ui
+            .tile_atlas
+            .get(&tile_id.0.to_string())
+            .unwrap_or(&self.ui.atlas)
+    }
+
     pub fn notice(&mut self, message: impl Into<String>, tone: StudioTone) {
         let id = format!("notice:{}", self.generation.saturating_add(1));
         self.ui.notices.push(StudioNotice {
@@ -663,7 +683,7 @@ impl StudioCore {
             schema_version: "ryeos.studio.envelope.v1".to_string(),
             generation: self.generation,
             view_model: super::view_model::build_view_model(self),
-            scene_model: super::scene_model::build_scene_model(self),
+            scene_model: super::scene_model::build_scene_model(self, &self.ui.atlas),
             effects,
         }
     }
@@ -688,7 +708,7 @@ impl StudioCore {
     pub fn focused_input_instance(&self) -> Option<(InputBufferKey, String)> {
         // Focused center tile first.
         let focused = self.workspace.focused_tile;
-        if let Some(ViewSpec::Bound { view_ref }) =
+        if let Some(ViewSpec { view_ref }) =
             self.workspace.tiles.get(&focused).map(|tile| &tile.view)
         {
             if let Some(input) = self.views.get(view_ref).and_then(|b| b.input.as_ref()) {

--- a/crates/clients/base/src/studio/reducer.rs
+++ b/crates/clients/base/src/studio/reducer.rs
@@ -68,24 +68,36 @@ impl StudioCore {
                 // view binding's params.
                 Vec::new()
             }
-            StudioUiEvent::SetAtlasLayerVisible { kind, visible } => {
-                self.ui.atlas.set_layer_visible(kind, visible);
+            StudioUiEvent::SetAtlasLayerVisible {
+                tile_id,
+                kind,
+                visible,
+            } => {
+                self.atlas_target_mut(&tile_id)
+                    .set_layer_visible(kind, visible);
                 self.bump_generation();
                 Vec::new()
             }
-            StudioUiEvent::SetAtlasLens { lens } => {
-                self.ui.atlas.set_lens(lens);
+            StudioUiEvent::SetAtlasLens { tile_id, lens } => {
+                self.atlas_target_mut(&tile_id).set_lens(lens);
                 self.bump_generation();
                 Vec::new()
             }
-            StudioUiEvent::SetAtlasProjection { projection, root } => {
-                self.ui.atlas.active_projection = projection;
-                if projection.is_file_space() {
-                    if let Some(root) = root {
-                        self.ui.atlas.file_space_root = root;
+            StudioUiEvent::SetAtlasProjection {
+                tile_id,
+                projection,
+                root,
+            } => {
+                {
+                    let atlas = self.atlas_target_mut(&tile_id);
+                    atlas.active_projection = projection;
+                    if projection.is_file_space() {
+                        if let Some(root) = root {
+                            atlas.file_space_root = root;
+                        }
+                        atlas.file_space_path.clear();
+                        atlas.set_lens(crate::atlas::AtlasLensVm::None);
                     }
-                    self.ui.atlas.file_space_path.clear();
-                    self.ui.atlas.set_lens(crate::atlas::AtlasLensVm::None);
                 }
                 self.bump_generation();
                 match projection {
@@ -99,9 +111,13 @@ impl StudioCore {
                     }
                     crate::atlas::AtlasProjectionVm::FileSpace => {
                         if self.has_project_bound() {
+                            let (root, path) = {
+                                let atlas = self.atlas_target(&tile_id);
+                                (atlas.file_space_root.clone(), atlas.file_space_path.clone())
+                            };
                             vec![self.emit(StudioEffectKind::FetchFileSpace {
-                                root: self.ui.atlas.file_space_root.clone(),
-                                path: self.ui.atlas.file_space_path.clone(),
+                                root,
+                                path,
                                 max_depth: 8,
                                 max_entries: 3000,
                             })]
@@ -111,16 +127,27 @@ impl StudioCore {
                     }
                 }
             }
-            StudioUiEvent::SetAtlasFileSpacePath { root, path } => {
-                self.ui.atlas.active_projection = crate::atlas::AtlasProjectionVm::FileSpace;
-                self.ui.atlas.file_space_root = root;
-                self.ui.atlas.file_space_path = path;
-                self.ui.atlas.set_lens(crate::atlas::AtlasLensVm::None);
+            StudioUiEvent::SetAtlasFileSpacePath {
+                tile_id,
+                root,
+                path,
+            } => {
+                {
+                    let atlas = self.atlas_target_mut(&tile_id);
+                    atlas.active_projection = crate::atlas::AtlasProjectionVm::FileSpace;
+                    atlas.file_space_root = root;
+                    atlas.file_space_path = path;
+                    atlas.set_lens(crate::atlas::AtlasLensVm::None);
+                }
                 self.bump_generation();
                 if self.has_project_bound() {
+                    let (root, path) = {
+                        let atlas = self.atlas_target(&tile_id);
+                        (atlas.file_space_root.clone(), atlas.file_space_path.clone())
+                    };
                     vec![self.emit(StudioEffectKind::FetchFileSpace {
-                        root: self.ui.atlas.file_space_root.clone(),
-                        path: self.ui.atlas.file_space_path.clone(),
+                        root,
+                        path,
                         max_depth: 8,
                         max_entries: 3000,
                     })]
@@ -781,7 +808,7 @@ impl StudioCore {
             self.workspace.tiles.get(tile_id).is_some_and(|tile| {
                 matches!(
                     &tile.view,
-                    ViewSpec::Bound { view_ref } if view_ref == "view:ryeos/item/inspector"
+                    ViewSpec { view_ref } if view_ref == "view:ryeos/item/inspector"
                 )
             })
         }) {
@@ -791,7 +818,7 @@ impl StudioCore {
             });
             return;
         }
-        self.add_tile_motions(ViewSpec::Bound {
+        self.add_tile_motions(ViewSpec {
             view_ref: "view:ryeos/item/inspector".to_string(),
         });
     }
@@ -813,18 +840,6 @@ impl StudioCore {
     }
 
     fn open_view(&mut self, view: ViewSpec) -> Vec<StudioEffect> {
-        if is_clear_center_view(&view) {
-            if !self.workspace.center_is_empty() {
-                for tile_id in self.workspace.tile_ids() {
-                    self.push_motion(StudioMotionEventVm::TileExit {
-                        tile_id: tile_id.0.to_string(),
-                    });
-                }
-            }
-            self.workspace.reset_to_empty();
-            self.bump_generation();
-            return self.effects_for_view(&view);
-        }
         for tile_id in self.workspace.tile_ids() {
             if self
                 .workspace
@@ -897,12 +912,9 @@ impl StudioCore {
 
     fn add_center_tile(&mut self, view: ViewSpec) -> Vec<StudioEffect> {
         let tile_id = self.add_tile_motions(view);
-        let view = self
-            .workspace
-            .tiles
-            .get(&tile_id)
-            .map(|tile| tile.view.clone())
-            .unwrap_or(ViewSpec::Graph { graph_id: None });
+        let Some(view) = self.workspace.tiles.get(&tile_id).map(|tile| tile.view.clone()) else {
+            return Vec::new();
+        };
         self.effects_for_view(&view)
     }
 
@@ -996,9 +1008,7 @@ impl StudioCore {
             .into_iter()
             .filter_map(|tile_id| {
                 let tile = self.workspace.tiles.get(&tile_id)?;
-                let ViewSpec::Bound { view_ref } = &tile.view else {
-                    return None;
-                };
+                let view_ref = &tile.view.view_ref;
                 let binding = self.views.get(view_ref)?;
                 let subscribed = binding.refresh.get("on_facet").and_then(|v| v.as_str())
                     == Some(facet)
@@ -1020,16 +1030,30 @@ impl StudioCore {
             .collect()
     }
 
+    /// Resolve the atlas arrangement a `SetAtlas*` event targets: `Some(tile)`
+    /// → that tile's per-tile arrangement, created from the default on first
+    /// touch; `None` → the ambient backdrop atlas.
+    fn atlas_target_mut(&mut self, tile_id: &Option<String>) -> &mut crate::atlas::AtlasUiStateVm {
+        match tile_id {
+            Some(id) => self.ui.tile_atlas.entry(id.clone()).or_default(),
+            None => &mut self.ui.atlas,
+        }
+    }
+
+    fn atlas_target(&self, tile_id: &Option<String>) -> &crate::atlas::AtlasUiStateVm {
+        match tile_id {
+            Some(id) => self.ui.tile_atlas.get(id).unwrap_or(&self.ui.atlas),
+            None => &self.ui.atlas,
+        }
+    }
+
     fn effects_for_view(&mut self, view: &ViewSpec) -> Vec<StudioEffect> {
-        match view {
-            ViewSpec::Bound { view_ref } => {
-                let view_ref = view_ref.clone();
-                let tile_id = self.workspace.focused_tile;
-                self.emit_fetch_source(tile_id, &view_ref)
-                    .into_iter()
-                    .collect()
-            }
-            ViewSpec::Atlas => vec![
+        let view_ref = view.view_ref.clone();
+        // Scene widgets pull engine data the generic source path doesn't
+        // carry; everything else fetches its declared source.
+        let widget = self.views.get(&view_ref).map(|binding| binding.widget.clone());
+        match widget.as_deref() {
+            Some("atlas") => vec![
                 self.emit(StudioEffectKind::FetchDimension),
                 self.emit(StudioEffectKind::FetchTopology),
                 self.emit(StudioEffectKind::FetchItems {
@@ -1039,10 +1063,16 @@ impl StudioCore {
                     limit: 1000,
                 }),
             ],
-            ViewSpec::Graph { .. } => vec![
+            Some("graph") => vec![
                 self.emit(StudioEffectKind::FetchDimension),
                 self.emit(StudioEffectKind::FetchTopology),
             ],
+            _ => {
+                let tile_id = self.workspace.focused_tile;
+                self.emit_fetch_source(tile_id, &view_ref)
+                    .into_iter()
+                    .collect()
+            }
         }
     }
 
@@ -1360,11 +1390,6 @@ fn arrange_axis_vm(arrange: ArrangeSpec) -> StudioSplitAxisVm {
     }
 }
 
-/// Opening the bare topology view clears the center to empty (the
-/// ambient topology / backdrop owns the frame) rather than adding a tile.
-fn is_clear_center_view(view: &ViewSpec) -> bool {
-    matches!(view, ViewSpec::Graph { graph_id: None })
-}
 
 fn filtered_launcher_items(core: &StudioCore) -> Vec<super::view_model::StudioLauncherItemVm> {
     let query = core.ui.launcher.query.trim().to_lowercase();
@@ -1538,28 +1563,17 @@ fn file_root_requires_project(root: &str) -> bool {
     matches!(root, "project" | "project_ai")
 }
 
+/// A route is the view's own ref — every view is addressable by ref
+/// (`#view:…`), graph/atlas included. The engine names no specific view.
 fn view_from_route(route: &str) -> Option<ViewSpec> {
-    // Routes name engine views only; content views address by ref
-    // (`#view:…`).
     let route = route.trim_start_matches('#');
-    if let Some(view_ref) = route.strip_prefix("view:").map(|_| route) {
-        return Some(ViewSpec::Bound {
-            view_ref: view_ref.to_string(),
-        });
-    }
-    match route {
-        "" | "graph" => Some(ViewSpec::Graph { graph_id: None }),
-        "atlas" => Some(ViewSpec::Atlas),
-        _ => None,
-    }
+    route
+        .starts_with("view:")
+        .then(|| ViewSpec::bound(route))
 }
 
-fn route_for_view(view: &ViewSpec) -> Option<&'static str> {
-    match view {
-        ViewSpec::Atlas => Some("atlas"),
-        ViewSpec::Graph { graph_id: None } => Some("graph"),
-        ViewSpec::Bound { .. } | ViewSpec::Graph { graph_id: Some(_) } => None,
-    }
+fn route_for_view(view: &ViewSpec) -> Option<String> {
+    Some(view.view_ref.clone())
 }
 
 fn effect_matches_current_items(expected: Option<&StudioEffectKind>, core: &StudioCore) -> bool {
@@ -1739,7 +1753,7 @@ mod tests {
         );
         let tile_id = core
             .workspace
-            .add_tile(ViewSpec::Bound {
+            .add_tile(ViewSpec {
                 view_ref: "view:test/inspector".to_string(),
             })
             .0
@@ -1877,10 +1891,15 @@ mod tests {
     #[test]
     fn graph_view_effects_fetch_topology() {
         let mut core = StudioCore::new(session(), BrowserViewport::default(), 0);
+        seed_view_value(
+            &mut core,
+            "view:ryeos/graph/topology",
+            serde_json::json!({ "widget": "graph" }),
+        );
         let effects = core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Graph { graph_id: None },
+                    view: ViewSpec::bound("view:ryeos/graph/topology"),
                 },
             },
         });
@@ -1933,7 +1952,7 @@ mod tests {
             },
         });
 
-        let scene = crate::studio::scene_model::build_scene_model(&core);
+        let scene = crate::studio::scene_model::build_scene_model(&core, &core.ui.atlas);
         let atlas = scene.atlas.expect("atlas surface should build scene atlas");
         assert_eq!(atlas.root_label, ".ai");
         assert!(atlas
@@ -1980,7 +1999,7 @@ mod tests {
     }
 
     #[test]
-    fn launcher_includes_engine_views_and_content_library() {
+    fn launcher_lists_embedded_views_including_scene_widgets() {
         let mut core = StudioCore::default();
         core.views.insert(
             "view:ryeos/threads/list".to_string(),
@@ -1990,14 +2009,20 @@ mod tests {
             }))
             .unwrap(),
         );
+        // Graph/atlas are ordinary embedded views now — no hardcoded items.
+        core.views.insert(
+            "view:ryeos/graph/topology".to_string(),
+            serde_json::from_value(serde_json::json!({ "widget": "graph" })).unwrap(),
+        );
         let items = launcher_items(&core);
+        // The scene-widget view launches as a Bound tile, labeled by ref.
         assert!(items.iter().any(|item| {
-            item.label == "Graph"
+            item.label == "ryeos/graph/topology"
                 && matches!(
-                    item.action,
+                    &item.action,
                     StudioAction::OpenView {
-                        view: ViewSpec::Graph { graph_id: None }
-                    }
+                        view: ViewSpec { view_ref }
+                    } if view_ref == "view:ryeos/graph/topology"
                 )
         }));
         // Content views launch as Bound tiles, labeled by ref.
@@ -2006,7 +2031,7 @@ mod tests {
                 && matches!(
                     &item.action,
                     StudioAction::OpenView {
-                        view: ViewSpec::Bound { view_ref }
+                        view: ViewSpec { view_ref }
                     } if view_ref == "view:ryeos/threads/list"
                 )
         }));
@@ -2238,7 +2263,7 @@ mod tests {
 
         assert_eq!(
             core.workspace.focused_view(),
-            Some(&ViewSpec::Bound {
+            Some(&ViewSpec {
                 view_ref: "view:ryeos/items/space".to_string()
             })
         );
@@ -2544,7 +2569,7 @@ mod tests {
                 "input": { "id": "q", "placeholder": "filter…", "feeds": { "param": "query", "debounce_ms": 120 } }
             }),
         );
-        let tile_id = core.workspace.add_tile(ViewSpec::Bound {
+        let tile_id = core.workspace.add_tile(ViewSpec {
             view_ref: "view:test/filter".to_string(),
         });
         core.workspace.focused_tile = tile_id;
@@ -2619,7 +2644,7 @@ mod tests {
                 }]
             }),
         );
-        let tile_id = core.workspace.add_tile(ViewSpec::Bound {
+        let tile_id = core.workspace.add_tile(ViewSpec {
             view_ref: "view:test/palette".to_string(),
         });
         core.workspace.focused_tile = tile_id;
@@ -2655,7 +2680,7 @@ mod tests {
                 }]
             }),
         );
-        let tile_id = core.workspace.add_tile(ViewSpec::Bound {
+        let tile_id = core.workspace.add_tile(ViewSpec {
             view_ref: "view:test/palette".to_string(),
         });
         core.workspace.focused_tile = tile_id;
@@ -2683,10 +2708,10 @@ mod tests {
                 "input": { "id": "q", "feeds": { "param": "query" } }
             }),
         );
-        let first = core.workspace.add_tile(ViewSpec::Bound {
+        let first = core.workspace.add_tile(ViewSpec {
             view_ref: "view:test/filter".to_string(),
         });
-        let second = core.workspace.add_tile(ViewSpec::Bound {
+        let second = core.workspace.add_tile(ViewSpec {
             view_ref: "view:test/filter".to_string(),
         });
         assert_ne!(first, second);
@@ -3073,7 +3098,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/items/space".to_string(),
                     },
                 },
@@ -3083,7 +3108,7 @@ mod tests {
         let effects = core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3093,7 +3118,7 @@ mod tests {
         assert_eq!(core.workspace.tile_ids().len(), before + 1);
         assert!(matches!(
             core.workspace.focused_view(),
-            Some(ViewSpec::Bound { view_ref }) if view_ref == "view:test/services"
+            Some(ViewSpec { view_ref }) if view_ref == "view:test/services"
         ));
         assert!(core
             .ui
@@ -3117,7 +3142,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/items/space".to_string(),
                     },
                 },
@@ -3127,7 +3152,7 @@ mod tests {
         let effects = core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/items/space".to_string(),
                     },
                 },
@@ -3139,7 +3164,7 @@ mod tests {
             .tiles
             .values()
             .filter(|tile| {
-                matches!(&tile.view, ViewSpec::Bound { view_ref } if view_ref == "view:ryeos/items/space")
+                matches!(&tile.view, ViewSpec { view_ref } if view_ref == "view:ryeos/items/space")
             })
             .count();
         assert_eq!(core.workspace.tile_ids().len(), before + 1);
@@ -3161,7 +3186,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3170,7 +3195,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/threads/list".to_string(),
                     },
                 },
@@ -3199,7 +3224,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3252,7 +3277,7 @@ mod tests {
         assert!(!core.ui.launcher.open);
         assert!(matches!(
             core.workspace.focused_view(),
-            Some(ViewSpec::Bound { view_ref }) if view_ref == "view:ryeos/items/space"
+            Some(ViewSpec { view_ref }) if view_ref == "view:ryeos/items/space"
         ));
         assert!(matches!(
             effects.first().map(|effect| &effect.kind),
@@ -3266,7 +3291,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3277,7 +3302,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/threads/list".to_string(),
                     },
                 },
@@ -3302,7 +3327,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3311,7 +3336,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/threads/list".to_string(),
                     },
                 },
@@ -3320,7 +3345,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/files".to_string(),
                     },
                 },
@@ -3357,7 +3382,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3366,7 +3391,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/files".to_string(),
                     },
                 },
@@ -3387,7 +3412,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/files".to_string(),
                     },
                 },
@@ -3396,7 +3421,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenNewView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/items/space".to_string(),
                     },
                 },
@@ -3429,7 +3454,7 @@ mod tests {
         core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:test/services".to_string(),
                     },
                 },
@@ -3458,7 +3483,7 @@ mod tests {
         let effects = core.dispatch(StudioEvent::Ui {
             event: StudioUiEvent::Activate {
                 action: StudioAction::OpenView {
-                    view: ViewSpec::Bound {
+                    view: ViewSpec {
                         view_ref: "view:ryeos/items/space".to_string(),
                     },
                 },

--- a/crates/clients/base/src/studio/scene_model.rs
+++ b/crates/clients/base/src/studio/scene_model.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::atlas::{
     build_file_space_atlas, build_namespace_atlas, AtlasFileInput, AtlasFileSpaceInput, AtlasInput,
-    AtlasItemInput, AtlasProjectionVm, NamespaceAtlasVm,
+    AtlasItemInput, AtlasProjectionVm, AtlasUiStateVm, NamespaceAtlasVm,
 };
 
 use super::event::StudioAction;
@@ -80,7 +80,12 @@ impl Default for StudioSceneModel {
 
 use super::model::StudioCore;
 
-pub fn build_scene_model(core: &StudioCore) -> StudioSceneModel {
+/// Build the scene for one atlas arrangement. `atlas` is the relevant
+/// arrangement state: the ambient backdrop (`core.ui.atlas`) for the
+/// empty-center namespace_atlas, or a tile's per-tile state for an Atlas
+/// center tile. The underlying topology/item/file data is shared (global
+/// in `core.data`); `atlas` selects the projection, layers, and lens.
+pub fn build_scene_model(core: &StudioCore, atlas: &AtlasUiStateVm) -> StudioSceneModel {
     let mut scene = StudioSceneModel {
         generation: core.generation,
         ..StudioSceneModel::default()
@@ -321,7 +326,7 @@ pub fn build_scene_model(core: &StudioCore) -> StudioSceneModel {
         capabilities.sort();
         capabilities.dedup();
 
-        if core.ui.atlas.active_projection == AtlasProjectionVm::AiSpace {
+        if atlas.active_projection == AtlasProjectionVm::AiSpace {
             scene.atlas = Some(build_namespace_atlas(AtlasInput {
                 generation: core.generation,
                 root_label: ".ai".to_string(),
@@ -341,12 +346,12 @@ pub fn build_scene_model(core: &StudioCore) -> StudioSceneModel {
                 capabilities,
                 selected_ref,
                 context_refs: atlas_context_refs(core),
-                ui: core.ui.atlas.clone(),
+                ui: atlas.clone(),
             }));
         }
     }
 
-    if core.ui.atlas.active_projection == AtlasProjectionVm::FileSpace {
+    if atlas.active_projection == AtlasProjectionVm::FileSpace {
         let file_space = core.data.file_space.as_ref();
         let selected_ref = core
             .seat
@@ -385,7 +390,7 @@ pub fn build_scene_model(core: &StudioCore) -> StudioSceneModel {
                 })
                 .unwrap_or_default(),
             selected_ref,
-            ui: core.ui.atlas.clone(),
+            ui: atlas.clone(),
         }));
     }
 
@@ -688,7 +693,7 @@ mod tests {
             ..StudioItemsDto::default()
         });
 
-        let scene = build_scene_model(&core);
+        let scene = build_scene_model(&core, &core.ui.atlas);
         let atlas = scene.atlas.expect("atlas");
         assert_eq!(atlas.generation, 42);
         let stack_node = atlas
@@ -722,7 +727,7 @@ mod tests {
             ..Default::default()
         });
 
-        let scene = build_scene_model(&core);
+        let scene = build_scene_model(&core, &core.ui.atlas);
         let node = scene
             .objects
             .iter()
@@ -774,7 +779,7 @@ mod tests {
             ..Default::default()
         });
 
-        let scene = build_scene_model(&core);
+        let scene = build_scene_model(&core, &core.ui.atlas);
         let edge = scene
             .objects
             .iter()

--- a/crates/clients/base/src/studio/view_model.rs
+++ b/crates/clients/base/src/studio/view_model.rs
@@ -544,7 +544,7 @@ fn presentation_metrics_vm(
         .as_ref()
         .map(|dimension| dimension.threads.active_count)
         .unwrap_or_default();
-    let scene_object_count = build_scene_model(core).objects.len();
+    let scene_object_count = build_scene_model(core, &core.ui.atlas).objects.len();
     let activity_level = presentation_activity_level(
         workspace.tile_count,
         core.ui.motion.len(),
@@ -751,7 +751,7 @@ fn dock_tile_vm(
         edge,
         title: view_ref.rsplit('/').next().unwrap_or(view_ref).to_string(),
         size: state.size,
-        view: bound_view_vm_keyed(core, &source_key, None, view_ref),
+        view: bound_view_vm_keyed(core, &source_key, None, view_ref, &core.ui.atlas),
         input: instance_input_vm(core, &source_key, view_ref),
     })
 }
@@ -777,6 +777,7 @@ fn bound_view_vm(core: &StudioCore, tile_id: TileId, view_ref: &str) -> StudioVi
         &tile_id.0.to_string(),
         selected_cursor(core, tile_id),
         view_ref,
+        core.tile_atlas_state(tile_id),
     )
 }
 
@@ -785,6 +786,7 @@ fn bound_view_vm_keyed(
     source_key: &str,
     cursor: Option<usize>,
     view_ref: &str,
+    atlas: &crate::atlas::AtlasUiStateVm,
 ) -> StudioViewVm {
     let Some(binding) = core.views.get(view_ref) else {
         return StudioViewVm::Placeholder {
@@ -799,6 +801,22 @@ fn bound_view_vm_keyed(
             title: view_ref.to_string(),
             message: reason.clone(),
         };
+    }
+    // Engine scene widgets render from shared topology/item data + this
+    // tile's atlas arrangement, not from a per-tile source response — so
+    // they dispatch before the source-required arms below.
+    match binding.widget.as_str() {
+        "atlas" => {
+            return StudioViewVm::Atlas {
+                scene: build_scene_model(core, atlas),
+            }
+        }
+        "graph" => {
+            return StudioViewVm::Map {
+                scene: build_scene_model(core, atlas),
+            }
+        }
+        _ => {}
     }
     let response = core.data.sources.get(source_key);
     let title = view_ref.rsplit('/').next().unwrap_or(view_ref).to_string();
@@ -1175,11 +1193,8 @@ fn layout_node_vm(node: &LayoutTree, core: &StudioCore) -> StudioLayoutNodeVm {
                 .workspace
                 .tiles
                 .get(tile_id)
-                .and_then(|tile| match &tile.view {
-                    ViewSpec::Bound { view_ref } => {
-                        instance_input_vm(core, &tile_id.0.to_string(), view_ref)
-                    }
-                    _ => None,
+                .and_then(|tile| {
+                    instance_input_vm(core, &tile_id.0.to_string(), &tile.view.view_ref)
                 });
             StudioLayoutNodeVm::Tile {
                 tile_id: tile_id_text(*tile_id),
@@ -1208,15 +1223,9 @@ fn layout_node_vm(node: &LayoutTree, core: &StudioCore) -> StudioLayoutNodeVm {
 }
 
 fn view_vm(core: &StudioCore, tile_id: TileId, tile: &TileState) -> StudioViewVm {
-    match &tile.view {
-        ViewSpec::Bound { view_ref } => bound_view_vm(core, tile_id, view_ref),
-        ViewSpec::Atlas => StudioViewVm::Atlas {
-            scene: build_scene_model(core),
-        },
-        ViewSpec::Graph { .. } => StudioViewVm::Map {
-            scene: build_scene_model(core),
-        },
-    }
+    // Every tile is a bound view; the scene widgets (graph/atlas) dispatch
+    // by `widget` inside `bound_view_vm`.
+    bound_view_vm(core, tile_id, &tile.view.view_ref)
 }
 
 fn session_vm(core: &StudioCore) -> StudioSessionVm {
@@ -1290,29 +1299,13 @@ fn ambient_vm(core: &StudioCore) -> StudioAmbientVm {
     }
 }
 
-/// Launchable views: the surface's embedded content library plus the
-/// two engine ambient views (graph topology, atlas). Nothing here names
-/// a product concept — labels and hints come from the view items.
+/// Launchable views: every view embedded in the effective surface,
+/// graph/atlas included (they are ordinary `view:` items now). Nothing
+/// here names a product concept — labels and hints come from the items.
 pub(crate) fn launcher_items(core: &StudioCore) -> Vec<StudioLauncherItemVm> {
-    let mut items: Vec<StudioLauncherItemVm> = [
-        (
-            "Graph",
-            "RyeOS topology",
-            ViewSpec::Graph { graph_id: None },
-        ),
-        ("Atlas", "2D namespace map", ViewSpec::Atlas),
-    ]
-    .into_iter()
-    .map(|(label, hint, view)| StudioLauncherItemVm {
-        label: label.to_string(),
-        hint: hint.to_string(),
-        action: StudioAction::OpenView { view: view.clone() },
-        secondary_action: Some(StudioAction::OpenNewView { view }),
-        enabled: true,
-    })
-    .collect();
+    let mut items: Vec<StudioLauncherItemVm> = Vec::new();
     for (view_ref, binding) in &core.views {
-        let view = ViewSpec::Bound {
+        let view = ViewSpec {
             view_ref: view_ref.clone(),
         };
         items.push(StudioLauncherItemVm {
@@ -1472,12 +1465,11 @@ pub(crate) fn action_for_focused_row(core: &StudioCore) -> Option<StudioAction> 
 /// project their fetched source; the thread view projects the threads
 /// DTO; ambient views have no rows.
 fn focused_rows(core: &StudioCore, view: &ViewSpec, tile_id: TileId) -> Vec<StudioRowVm> {
-    match view {
-        ViewSpec::Bound { view_ref } => match bound_view_vm(core, tile_id, view_ref) {
-            StudioViewVm::Rows { rows, .. } => rows,
-            _ => Vec::new(),
-        },
-        ViewSpec::Atlas | ViewSpec::Graph { .. } => Vec::new(),
+    // Scene widgets (graph/atlas) render an Atlas/Map VM, not Rows, so the
+    // non-Rows fallback already yields no rows for them.
+    match bound_view_vm(core, tile_id, &view.view_ref) {
+        StudioViewVm::Rows { rows, .. } => rows,
+        _ => Vec::new(),
     }
 }
 

--- a/crates/clients/base/src/surface.rs
+++ b/crates/clients/base/src/surface.rs
@@ -67,7 +67,8 @@ pub struct SurfaceSpec {
     /// COMPUTED from this plus the ordered tile list — never authored.
     #[serde(default)]
     pub tiling: TilingSpec,
-    /// Ordered initial center tiles (`view:<ref>` | `atlas` | `graph`).
+    /// Ordered initial center tiles, each a `view:<ref>` (graph/atlas
+    /// included — they are ordinary `view:` items).
     #[serde(default)]
     pub tiles: Vec<ViewKindSpec>,
     /// Fixed edge slots; an absent edge has no slot.
@@ -357,62 +358,36 @@ impl BorderStyleSpec {
 // View kinds
 // ---------------------------------------------------------------------------
 
-/// Supported view kinds for center tiles. `Bound` carries a `view:` item
-/// ref — views-as-content; the remaining named kinds are sanctioned
-/// structural views.
+/// A center tile as authored in a surface: a `view:` item ref. Every
+/// tile is views-as-content — graph/atlas are ordinary `view:` items
+/// (their `widget:` does the rest), so there are no named structural
+/// kinds. Serializes as the bare ref string the surface YAML carries.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ViewKindSpec {
-    Atlas,
-    Graph,
-    /// A `view:` item reference (views-as-content).
-    Bound(String),
-}
-
-const VIEW_KIND_NAMES: &[(&str, fn() -> ViewKindSpec)] = &[
-    ("atlas", || ViewKindSpec::Atlas),
-    ("graph", || ViewKindSpec::Graph),
-];
+pub struct ViewKindSpec(pub String);
 
 impl Serialize for ViewKindSpec {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        if let ViewKindSpec::Bound(view_ref) = self {
-            return serializer.serialize_str(view_ref);
-        }
-        for (name, make) in VIEW_KIND_NAMES {
-            if make() == *self {
-                return serializer.serialize_str(name);
-            }
-        }
-        unreachable!("every non-Bound view kind has a name")
+        serializer.serialize_str(&self.0)
     }
 }
 
 impl<'de> Deserialize<'de> for ViewKindSpec {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let raw = String::deserialize(deserializer)?;
-        for (name, make) in VIEW_KIND_NAMES {
-            if *name == raw {
-                return Ok(make());
-            }
-        }
         if raw.starts_with("view:") {
-            return Ok(ViewKindSpec::Bound(raw));
+            return Ok(ViewKindSpec(raw));
         }
         Err(serde::de::Error::custom(format!(
-            "unknown pane view `{raw}` (named kind or view: ref expected)"
+            "unknown pane view `{raw}` (view: ref expected)"
         )))
     }
 }
 
 impl ViewKindSpec {
-    /// Convert to a ViewSpec with no ID binding.
+    /// Convert to a runtime ViewSpec.
     pub fn to_view_spec(&self) -> ViewSpec {
-        match self {
-            ViewKindSpec::Atlas => ViewSpec::Atlas,
-            ViewKindSpec::Graph => ViewSpec::Graph { graph_id: None },
-            ViewKindSpec::Bound(view_ref) => ViewSpec::Bound {
-                view_ref: view_ref.clone(),
-            },
+        ViewSpec {
+            view_ref: self.0.clone(),
         }
     }
 
@@ -1042,8 +1017,8 @@ tiling:
   insert: end
 tiles:
   - "view:ryeos/chain/timeline"
-  - atlas
-  - graph
+  - "view:ryeos/atlas"
+  - "view:ryeos/graph/topology"
 slots:
   bottom: { content: "view:ryeos/input", open: true, size: 7 }
   left: { content: "view:ryeos/threads/list", open: false, size: 32 }
@@ -1059,9 +1034,9 @@ style:
         assert_eq!(spec.tiles.len(), 3);
         assert_eq!(
             spec.tiles[0],
-            ViewKindSpec::Bound("view:ryeos/chain/timeline".into())
+            ViewKindSpec("view:ryeos/chain/timeline".into())
         );
-        assert_eq!(spec.tiles[1], ViewKindSpec::Atlas);
+        assert_eq!(spec.tiles[1], ViewKindSpec("view:ryeos/atlas".into()));
         // Edges not named have no slot.
         assert!(spec.slots.right.is_none());
         assert!(spec.slots.top.is_none());
@@ -1128,22 +1103,24 @@ style:
 
     #[test]
     fn to_workspace_preserves_tile_order() {
-        let spec: SurfaceSpec =
-            serde_yaml::from_str("name: x\ntiles: [\"view:a/b\", graph, atlas]\n").unwrap();
+        let spec: SurfaceSpec = serde_yaml::from_str(
+            "name: x\ntiles: [\"view:a/b\", \"view:ryeos/graph/topology\", \"view:ryeos/atlas\"]\n",
+        )
+        .unwrap();
         let ws = spec.to_workspace();
         let ids = ws.tile_ids();
         assert_eq!(ids.len(), 3);
         assert!(matches!(
             ws.tiles.get(&ids[0]).map(|t| &t.view),
-            Some(ViewSpec::Bound { view_ref }) if view_ref == "view:a/b"
+            Some(ViewSpec { view_ref }) if view_ref == "view:a/b"
         ));
         assert!(matches!(
             ws.tiles.get(&ids[1]).map(|t| &t.view),
-            Some(ViewSpec::Graph { .. })
+            Some(ViewSpec { view_ref }) if view_ref == "view:ryeos/graph/topology"
         ));
         assert!(matches!(
             ws.tiles.get(&ids[2]).map(|t| &t.view),
-            Some(ViewSpec::Atlas)
+            Some(ViewSpec { view_ref }) if view_ref == "view:ryeos/atlas"
         ));
         assert_eq!(ws.focused_tile, ids[0]);
         // Bound tiles carry generic list local state.
@@ -1231,13 +1208,14 @@ tiles = ["view:ryeos/threads/list"]
 
     #[test]
     fn view_kind_initial_local_state() {
+        // Every tile is a bound view and gets list-local state.
         assert!(matches!(
-            ViewKindSpec::Bound("view:test/x".into()).initial_local_state(),
+            ViewKindSpec("view:test/x".into()).initial_local_state(),
             ViewLocalState::GenericList { .. }
         ));
         assert!(matches!(
-            ViewKindSpec::Atlas.initial_local_state(),
-            ViewLocalState::None
+            ViewKindSpec("view:ryeos/atlas".into()).initial_local_state(),
+            ViewLocalState::GenericList { .. }
         ));
     }
 
@@ -1268,14 +1246,14 @@ tiles = ["view:ryeos/threads/list"]
 
     #[test]
     fn view_kind_to_view_spec_roundtrip() {
-        assert!(matches!(
-            ViewKindSpec::Bound("view:test/x".into()).to_view_spec(),
-            ViewSpec::Bound { .. }
-        ));
-        assert!(matches!(
-            ViewKindSpec::Graph.to_view_spec(),
-            ViewSpec::Graph { .. }
-        ));
+        assert_eq!(
+            ViewKindSpec("view:test/x".into()).to_view_spec(),
+            ViewSpec::bound("view:test/x")
+        );
+        assert_eq!(
+            ViewKindSpec("view:ryeos/graph/topology".into()).to_view_spec(),
+            ViewSpec::bound("view:ryeos/graph/topology")
+        );
     }
 
     #[test]
@@ -1325,9 +1303,21 @@ tiles = ["view:ryeos/threads/list"]
                 "legacy pane name `{legacy}` must be rejected"
             );
         }
-        for kept in ["atlas", "graph", "view:ryeos/threads/list"] {
+        // Bare named kinds are gone — graph/atlas are `view:` refs now.
+        for rejected in ["atlas", "graph"] {
+            let parsed: Result<ViewKindSpec, _> = serde_yaml::from_str(&format!("\"{rejected}\""));
+            assert!(
+                parsed.is_err(),
+                "bare named kind `{rejected}` must be rejected"
+            );
+        }
+        for kept in [
+            "view:ryeos/threads/list",
+            "view:ryeos/atlas",
+            "view:ryeos/graph/topology",
+        ] {
             let parsed: Result<ViewKindSpec, _> = serde_yaml::from_str(&format!("\"{kept}\""));
-            assert!(parsed.is_ok(), "pane name `{kept}` must parse");
+            assert!(parsed.is_ok(), "view ref `{kept}` must parse");
         }
     }
 
@@ -1349,7 +1339,7 @@ tiles = ["view:ryeos/threads/list"]
         assert!(
             spec.tiles
                 .iter()
-                .any(|tile| matches!(tile, ViewKindSpec::Bound(view_ref)
+                .any(|tile| matches!(tile, ViewKindSpec(view_ref)
                     if view_ref == "view:ryeos/threads/list")),
             "workbench must bind the threads view by ref"
         );
@@ -1522,7 +1512,7 @@ id = "test"
             "provenance": provenance_json("surface:ryeos/studio/graph", []),
             "composed_value": {
                 "name": "graph",
-                "tiles": ["graph"],
+                "tiles": ["view:ryeos/graph/topology"],
                 "affordances": []
             },
             "derived": {},

--- a/crates/clients/base/src/workspace.rs
+++ b/crates/clients/base/src/workspace.rs
@@ -16,15 +16,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 // View specs
 // ---------------------------------------------------------------------------
 
+/// A center tile: a `view:` item ref (views-as-content). Every product
+/// concept renders through this — graph/atlas included, via their
+/// `widget:`. Tiles are bindings, not code; this is the one uniform
+/// content form. The engine never names a specific view ref: which views
+/// exist is a content/surface concern, not engine code.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum ViewSpec {
-    /// A `view:` item-bound tile (views-as-content). Every product
-    /// concept renders through this — tiles are bindings, not code.
-    Bound { view_ref: String },
-    /// Engine ambient: 3D topology.
-    Graph { graph_id: Option<String> },
-    /// Engine ambient: 2D namespace atlas.
-    Atlas,
+pub struct ViewSpec {
+    pub view_ref: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,48 +62,33 @@ pub enum InputCapability {
 }
 
 impl ViewSpec {
+    /// Bind a `view:` ref.
+    pub fn bound(view_ref: impl Into<String>) -> Self {
+        Self {
+            view_ref: view_ref.into(),
+        }
+    }
+
     pub fn initial_local_state(&self) -> ViewLocalState {
-        match self {
-            ViewSpec::Bound { .. } => ViewLocalState::GenericList {
-                cursor: 0,
-                scroll: 0,
-            },
-            ViewSpec::Atlas | ViewSpec::Graph { .. } => ViewLocalState::None,
+        // Every bound tile gets list-local state; for the scene widgets
+        // (graph/atlas) the cursor is simply unused.
+        ViewLocalState::GenericList {
+            cursor: 0,
+            scroll: 0,
         }
     }
 
     pub fn input_capability(&self) -> InputCapability {
-        match self {
-            ViewSpec::Bound { .. } | ViewSpec::Atlas | ViewSpec::Graph { .. } => {
-                InputCapability::None
-            }
-        }
+        InputCapability::None
     }
 
-    /// Human-readable label for the input context hint.
-    pub fn input_hint(&self) -> &'static str {
-        match self {
-            ViewSpec::Bound { .. } => "view",
-            ViewSpec::Atlas => "atlas",
-            ViewSpec::Graph { .. } => "graph",
-        }
-    }
-
-    /// Short title for tile header.
+    /// Short title for tile header — the trailing segment of the ref.
     pub fn title(&self) -> String {
-        match self {
-            ViewSpec::Bound { view_ref } => {
-                view_ref.rsplit('/').next().unwrap_or(view_ref).to_string()
-            }
-            ViewSpec::Atlas => "Atlas".into(),
-            ViewSpec::Graph { graph_id } => {
-                if let Some(id) = graph_id {
-                    format!("Graph: {}", id)
-                } else {
-                    "Graph".into()
-                }
-            }
-        }
+        self.view_ref
+            .rsplit('/')
+            .next()
+            .unwrap_or(&self.view_ref)
+            .to_string()
     }
 }
 
@@ -527,7 +511,7 @@ mod tests {
     }
 
     fn bound(name: &str) -> ViewSpec {
-        ViewSpec::Bound {
+        ViewSpec {
             view_ref: format!("view:test/{name}"),
         }
     }

--- a/crates/daemon/ryeos-api/src/handlers/commands_submit.rs
+++ b/crates/daemon/ryeos-api/src/handlers/commands_submit.rs
@@ -4,13 +4,19 @@
 //! not from a client-supplied `requested_by` field. This prevents
 //! caller-forgery: only cryptographically verified callers get their
 //! fingerprint recorded as `requested_by`.
+//!
+//! Ownership check: callers can only submit control commands (cancel /
+//! kill / interrupt / continue) to threads they own. This mirrors the
+//! read path (`events/replay`, chain-tail) and the other control path
+//! (`threads/cancel`) — holding the capability is not enough; the caller
+//! must be the thread's owner.
 
 use std::sync::Arc;
 
-use anyhow::Result;
 use serde_json::Value;
 
 use crate::handler_context::HandlerContext;
+use crate::handler_error::HandlerError;
 use crate::registry::ServiceDescriptor;
 use ryeos_app::command_service::CommandSubmitParams;
 use ryeos_app::state::AppState;
@@ -25,7 +31,22 @@ pub struct Request {
     pub params: Option<Value>,
 }
 
-pub async fn handle(req: Request, ctx: HandlerContext, state: Arc<AppState>) -> Result<Value> {
+pub async fn handle(
+    req: Request,
+    ctx: HandlerContext,
+    state: Arc<AppState>,
+) -> Result<Value, HandlerError> {
+    // Ownership check: callers can only control their own threads. The
+    // service layer also loads the thread for its state-machine guard;
+    // we load here to keep authz in the API layer where the verified
+    // caller context lives.
+    let thread = state
+        .state_store
+        .get_thread(&req.thread_id)
+        .map_err(|e| HandlerError::Internal(e.to_string()))?
+        .ok_or(HandlerError::NotFound)?;
+    ctx.require_owner(thread.requested_by.as_deref())?;
+
     // Derive requested_by from verified caller context.
     // Only cryptographically verified callers get recorded.
     let requested_by = if ctx.is_present() {
@@ -34,13 +55,16 @@ pub async fn handle(req: Request, ctx: HandlerContext, state: Arc<AppState>) -> 
         None
     };
 
-    let record = state.commands.submit(&CommandSubmitParams {
-        thread_id: req.thread_id,
-        command_type: req.command_type,
-        requested_by,
-        params: req.params,
-    })?;
-    serde_json::to_value(record).map_err(Into::into)
+    let record = state
+        .commands
+        .submit(&CommandSubmitParams {
+            thread_id: req.thread_id,
+            command_type: req.command_type,
+            requested_by,
+            params: req.params,
+        })
+        .map_err(|e| HandlerError::Internal(e.to_string()))?;
+    serde_json::to_value(record).map_err(|e| HandlerError::Internal(e.to_string()))
 }
 
 pub const DESCRIPTOR: ServiceDescriptor = ServiceDescriptor {
@@ -51,7 +75,7 @@ pub const DESCRIPTOR: ServiceDescriptor = ServiceDescriptor {
     handler: |params, ctx, state| {
         Box::pin(async move {
             let req: Request = crate::handler_error::parse_request(params)?;
-            handle(req, ctx, state).await
+            handle(req, ctx, state).await.map_err(Into::into)
         })
     },
 };
@@ -83,5 +107,34 @@ mod tests {
             result.is_err(),
             "spoofed requested_by should be rejected by deny_unknown_fields"
         );
+    }
+
+    #[test]
+    fn require_owner_blocks_non_owner_as_not_found() {
+        // The ownership guard the handler applies before submitting:
+        // a verified caller whose fingerprint differs from the thread's
+        // owner gets NotFound (never 403 — no existence leak).
+        let ctx = HandlerContext::new("fp:attacker".to_string(), Vec::new(), true);
+        let err = ctx
+            .require_owner(Some("fp:owner"))
+            .expect_err("non-owner must be rejected");
+        assert!(
+            matches!(err, HandlerError::NotFound),
+            "non-owner should get NotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn require_owner_allows_matching_owner() {
+        let ctx = HandlerContext::new("fp:owner".to_string(), Vec::new(), true);
+        assert!(ctx.require_owner(Some("fp:owner")).is_ok());
+    }
+
+    #[test]
+    fn require_owner_rejects_unverified_caller() {
+        // Even a fingerprint match must fail when the caller is not
+        // cryptographically verified (fail-closed).
+        let ctx = HandlerContext::new("fp:owner".to_string(), Vec::new(), false);
+        assert!(ctx.require_owner(Some("fp:owner")).is_err());
     }
 }


### PR DESCRIPTION
## What

Collapses the graph/atlas special-casing in Studio shared-core into ordinary `view:` content items, keyed only on the **widget vocabulary** the engine legitimately owns.

Graph and atlas were hardcoded engine concepts — dedicated `ViewSpec`/`ViewKindSpec` enum variants, named view-ref constants, and route names the reducer matched against. That made "which views exist" engine code (the fire-sword anti-pattern: a specific product concept baked into a generic engine).

## Changes

- `ViewSpec` / `ViewKindSpec` enums → a single bound form carrying a `view_ref` string; the engine names no specific view identity.
- Render/effect dispatch keys on `binding.widget` (`atlas`/`graph` alongside `rows`/`timeline`/`text`), not on the ref.
- Routes are pure `view:` ref pass-through; opening any view uniformly adds/focuses a tile (`is_clear_center_view` deleted).
- **Per-tile** atlas/graph state: `ui.tile_atlas` keyed by `TileId` selects the arrangement (projection/layers/lens), falling back to the ambient `ui.atlas` backdrop. Scene data stays global; per-tile state selects the view onto it. `build_scene_model` takes the atlas state explicitly.
- Adds signed bundle view defs `view:ryeos/atlas` + `view:ryeos/graph/topology`; `workbench.yaml` now points at `view:ryeos/graph/topology`.

## Verification

- `cargo test -p ryeos-client-base` → 212 passed, 0 failed
- Dependent client crates (`ryeos-ui-terminal`, `ryeos-ui-web`) compile clean
- All three new/edited bundle files carry valid publisher signatures (verified against the dev trust key)

> Note: this branch is based on two `next` commits not yet on `origin/next` (`4510c4bc`, `af06e77c`). The diff narrows to the single refactor commit once `next` is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)