### PR TITLE
Fix CI fixtures for current runtime contracts

### DIFF
--- a/crates/bin/daemon/tests/scheduler_e2e.rs
+++ b/crates/bin/daemon/tests/scheduler_e2e.rs
@@ -627,9 +627,20 @@ async fn scheduler_pause_prevents_fires() {
     .await;
     assert!(status.is_success());
 
-    // Observe show_fires for 3 consecutive checks over 3s — count should
-    // stay at 1, proving no new fires appeared after pause.
-    let stable = observe_fire_count_stable(&h, "pause-no-fire", 1, 3, Duration::from_secs(3)).await;
+    // A boundary already claimed before the pause write gate linearizes may
+    // legitimately be visible now. From the successful pause response onward,
+    // however, the count must remain stable.
+    let count_after_pause = fire_count(&h, "pause-no-fire")
+        .await
+        .expect("show_fires after pause");
+    let stable = observe_fire_count_stable(
+        &h,
+        "pause-no-fire",
+        count_after_pause,
+        3,
+        Duration::from_secs(3),
+    )
+    .await;
     assert!(
         stable,
         "paused schedule should not produce additional fires"
@@ -690,13 +701,21 @@ async fn scheduler_deregister_stops_fires() {
         "deregistered schedule should not appear in list"
     );
 
-    // Observe show_fires for 3 consecutive checks over 3s — count should
-    // stay at 1, proving no new fires appeared after deregister.
-    let stable = observe_fire_count_stable(&h, "dereg-stop", 1, 3, Duration::from_secs(3)).await;
-    assert!(
-        stable,
-        "deregistered schedule should not produce additional fires"
-    );
+    // `show_fires` is owner-authorized through the live schedule spec and
+    // therefore returns not-found after deregistration. Inspect the durable
+    // fire projection instead: completion may still update an already-claimed
+    // row, but the successful response is the fence after which no new fire
+    // identity may be claimed.
+    let count_after_deregister =
+        projected_fire_count(&h, "dereg-stop").expect("read projected fires after deregister");
+    for _ in 0..3 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert_eq!(
+            projected_fire_count(&h, "dereg-stop"),
+            Some(count_after_deregister),
+            "deregistered schedule should not claim additional fires"
+        );
+    }
 }
 
 // ── Schedule ID reuse blocked ──────────────────────────────────────────────
@@ -1031,6 +1050,40 @@ async fn poll_for_fires_count(
     }
 }
 
+async fn fire_count(h: &DaemonHarness, schedule_id: &str) -> Option<u64> {
+    let (status, body) = exec(
+        h,
+        "service:scheduler/show_fires",
+        json!({
+            "schedule_id": schedule_id,
+        }),
+    )
+    .await;
+    if !status.is_success() {
+        return None;
+    }
+    body.get("result")?.get("total")?.as_u64()
+}
+
+fn projected_fire_count(h: &DaemonHarness, schedule_id: &str) -> Option<u64> {
+    let path = h
+        .state_path
+        .join(ryeos_engine::AI_DIR)
+        .join("state")
+        .join("scheduler.sqlite3");
+    let connection =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .ok()?;
+    let count = connection
+        .query_row(
+            "SELECT COUNT(*) FROM schedule_fires WHERE schedule_id = ?1",
+            [schedule_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .ok()?;
+    u64::try_from(count).ok()
+}
+
 /// Observe `show_fires` over a time window, checking that the fire count
 /// stays stable at `expected_count` for `consecutive` consecutive checks.
 /// Spreads checks evenly across `window` duration.
@@ -1045,22 +1098,7 @@ async fn observe_fire_count_stable(
     let interval = window / consecutive as u32;
     for _ in 0..consecutive {
         tokio::time::sleep(interval).await;
-        let (status, body) = exec(
-            h,
-            "service:scheduler/show_fires",
-            json!({
-                "schedule_id": schedule_id,
-            }),
-        )
-        .await;
-        if !status.is_success() {
-            continue;
-        }
-        let total = body
-            .get("result")
-            .and_then(|r| r["total"].as_u64())
-            .unwrap_or(u64::MAX);
-        if total != expected_count {
+        if fire_count(h, schedule_id).await != Some(expected_count) {
             return false;
         }
     }

--- a/crates/daemon/ryeos-node/src/init.rs
+++ b/crates/daemon/ryeos-node/src/init.rs
@@ -1760,6 +1760,7 @@ typo_field: oops
             "name: needy\nversion: '1.0'\nrequires_kinds:\n  - nonexistent-kind\n",
         )
         .unwrap();
+        materialize_test_manifest(&needy, "needy");
 
         let opts = InitOptions {
             app_root: state.clone(),

--- a/crates/tools/core-tools/tests/publish_declarative.rs
+++ b/crates/tools/core-tools/tests/publish_declarative.rs
@@ -85,7 +85,24 @@ fn stage_core_handler_binaries(registry: &Path) {
         "ryeos-core-tools",
     ] {
         let path = bin_dir.join(name);
-        std::fs::write(&path, format!("#!/bin/sh\necho test {name}\n")).unwrap();
+        let script = if name == "rye-parser-yaml-document" {
+            r###"#!/bin/sh
+request="$(cat)"
+case "$request" in
+  *'"command":"validate_parser_config"'*)
+    response='{"result":"validate_ok"}'
+    ;;
+  *)
+    response='{"result":"parse_ok","value":{"version":"1"}}'
+    ;;
+esac
+printf '%s\n' "$response"
+"###
+            .to_string()
+        } else {
+            format!("#!/bin/sh\necho test {name}\n")
+        };
+        std::fs::write(&path, script).unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -231,13 +248,11 @@ fn declarative_publish_requires_trust_for_registry_signed_by_different_key() {
     );
 }
 
-/// A publish must never sweep node runtime state into the sign report. The
-/// `node` kind's directory is `.ai/node`, which also holds `.ai/node/schedules`
-/// and `.ai/node/routes` — runtime-owned prefixes a running daemon writes. The
-/// runtime-owned floor excludes them before extension checks, so they never
-/// become items and never raise namespace warnings.
+/// Bundle publication authors declarative node configuration, but must never
+/// sweep signing secrets into the sign report. Project/operator signing uses a
+/// narrower ownership boundary and continues to exclude node-owned paths.
 #[test]
-fn publish_excludes_runtime_owned_node_paths_from_sign_report() {
+fn publish_signs_bundle_node_configuration_and_excludes_secrets() {
     if !core_bundle().join(ryeos_engine::AI_DIR).is_dir() {
         eprintln!("skipping: bundles/core not found");
         return;
@@ -247,7 +262,8 @@ fn publish_excludes_runtime_owned_node_paths_from_sign_report() {
     let bundle = create_declarative_bundle(tmp.path());
     let registry = prepare_core_registry(tmp.path(), &key);
 
-    // Seed node runtime state that the `node` kind walk would otherwise sweep.
+    // Seed bundle-authored node configuration and secret material. Declarative
+    // node items must be publisher-signed; secrets must remain outside the walk.
     let ai = bundle.join(ryeos_engine::AI_DIR);
     for (rel, body) in [
         ("node/schedules/nightly.yaml", "version: \"1\"\n"),
@@ -258,6 +274,9 @@ fn publish_excludes_runtime_owned_node_paths_from_sign_report() {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, body).unwrap();
     }
+    let secret = ai.join("config/keys/signing/private_key.yaml");
+    std::fs::create_dir_all(secret.parent().unwrap()).unwrap();
+    std::fs::write(&secret, "version: \"1\"\n").unwrap();
 
     let report = run_publish_once(&bundle, &registry, &key);
 
@@ -271,28 +290,51 @@ fn publish_excludes_runtime_owned_node_paths_from_sign_report() {
     {
         refs.push(outcome.item_ref.as_str());
     }
-    for r in &refs {
+    for expected in [
+        "node:schedules/nightly",
+        "node:routes/inbound",
+        "node:bundles/core",
+    ] {
         assert!(
-            !r.contains("schedules") && !r.contains("routes") && !r.contains("bundles"),
-            "runtime-owned node path leaked into sign report as `{r}`"
+            refs.contains(&expected),
+            "bundle-authored node item `{expected}` missing from sign report: {refs:?}"
         );
     }
     assert!(
+        refs.iter()
+            .all(|item_ref| !item_ref.contains("private_key")),
+        "secret material leaked into sign report: {refs:?}"
+    );
+    assert!(
         report.sign_report.warnings.is_empty(),
-        "runtime-owned exclusion should leave the namespace lint clean, got: {:?}",
+        "bundle node configuration should leave the namespace lint clean, got: {:?}",
         report.sign_report.warnings
     );
-    // The runtime YAMLs must remain unsigned on disk — a bundle publish must
-    // not author node runtime state.
-    let scheduled = std::fs::read_to_string(ai.join("node/schedules/nightly.yaml")).unwrap();
+    for rel in [
+        "node/schedules/nightly.yaml",
+        "node/routes/inbound.yaml",
+        "node/bundles/core.yaml",
+    ] {
+        let body = std::fs::read_to_string(ai.join(rel)).unwrap();
+        assert!(
+            lillux::signature::parse_signature_line(
+                body.lines().next().unwrap_or_default(),
+                "#",
+                None
+            )
+            .is_some(),
+            "bundle-authored node configuration `{rel}` must be signed"
+        );
+    }
+    let secret_body = std::fs::read_to_string(secret).unwrap();
     assert!(
         lillux::signature::parse_signature_line(
-            scheduled.lines().next().unwrap_or_default(),
+            secret_body.lines().next().unwrap_or_default(),
             "#",
             None
         )
         .is_none(),
-        "node runtime state must not be signed by publish"
+        "signing secret must remain unsigned"
     );
 }
 


### PR DESCRIPTION
Updates stale bundle-publish and init fixtures to the current contracts, and makes scheduler pause/deregister stability assertions race-safe and fail-closed.\n\nValidation is delegated to GitHub CI; no local builds or tests were run per machine constraints.